### PR TITLE
Update builder to use Puppet 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
 FROM centos:7
 
-# Python 3.6 and other build tools
-RUN rpm -ivh http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm && \
-                yum install -y centos-release-scl puppet-agent && \
-                yum install -y rh-python36 git rsync bzip2 unzip && \
-                rm -rf /var/cache/yum && \
-                . /opt/rh/rh-python36/enable && \
-                pip install tox
+# Add repos for Puppet and Puppet Development Kit
+RUN rpm -ivh https://yum.puppetlabs.com/puppet6-release-el-7.noarch.rpm
+RUN rpm -ivh https://yum.puppetlabs.com/puppet-tools-release-el-7.noarch.rpm
 
-# Fix buggy pip
-RUN . /opt/rh/rh-python36/enable && \
-      pip install --upgrade "git+https://github.com/EmmEff/pip2pi.git@pip-10-fix#egg=pip2pi-0.7.0"
-                
+# Install Centos software collections repo
+RUN yum install -y centos-release-scl
+
+# Install Python 3.6 and other build tools
+RUN yum update -y && yum install -y \
+    bzip2 \
+    git \
+    rh-python36 \
+    rsync \
+    unzip \
+    pdk \
+    puppet-agent
+
+# Clean yum cache
+RUN rm -rf /var/cache/yum
+
 # Make sure the environment is set up right
 ADD scripts/entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,21 @@
 FROM centos:7
 
 # Add repos for Puppet and Puppet Development Kit
-RUN rpm -ivh https://yum.puppetlabs.com/puppet6-release-el-7.noarch.rpm
-RUN rpm -ivh https://yum.puppetlabs.com/puppet-tools-release-el-7.noarch.rpm
-
 # Install Centos software collections repo
-RUN yum install -y centos-release-scl
-
 # Install Python 3.6 and other build tools
-RUN yum update -y && yum install -y \
-    bzip2 \
-    git \
-    rh-python36 \
-    rsync \
-    unzip \
-    pdk \
-    puppet-agent
-
-# Clean yum cache
-RUN rm -rf /var/cache/yum
+RUN rpm -ivh https://yum.puppetlabs.com/puppet6-release-el-7.noarch.rpm \
+    && rpm -ivh https://yum.puppetlabs.com/puppet-tools-release-el-7.noarch.rpm \
+    && yum install -y centos-release-scl \
+    && yum update -y \
+    && yum install -y \
+        bzip2 \
+        git \
+        rh-python36 \
+        rsync \
+        unzip \
+        pdk \
+        puppet-agent \
+    && yum clean all
 
 # Make sure the environment is set up right
 ADD scripts/entrypoint.sh /


### PR DESCRIPTION
I've built this image and used it to build Tortuga, and then installed the new Tortuga build successfully. I also removed the use of non-standard `pip`.